### PR TITLE
Renamed multinet topologies name to be compatible with NSTAT

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -15,7 +15,7 @@
 		"controller_ip_address":"10.1.38.45",
 		"controller_of_port":6653,
 		"switch_type":"ovsk",
-		"topo_type":"linear",
+		"topo_type":"Linear",
 		"topo_size":450,
 		"group_size":1,
 		"group_delay":10000,

--- a/config/test-config.json
+++ b/config/test-config.json
@@ -15,7 +15,7 @@
 		"controller_ip_address":"10.1.1.39",
 		"controller_of_port":6653,
 		"switch_type":"ovsk",
-		"topo_type":"linear",
+		"topo_type":"Linear",
 		"topo_size":10,
 		"group_size":10,
 		"group_delay":100,

--- a/net/multinet.py
+++ b/net/multinet.py
@@ -34,12 +34,12 @@ class Multinet(mininet.net.Mininet):
 
     """
     name - class correspondence for the topologies
-    """ 
+    """
     TOPOS = {
-        'disconnected': net.topologies.DisconnectedTopo,
-        'linear': net.topologies.LinearTopo,
-        'ring': net.topologies.RingTopo,
-        'mesh': net.topologies.MeshTopo
+        'Disconnected': net.topologies.DisconnectedTopo,
+        'Linear': net.topologies.LinearTopo,
+        'Ring': net.topologies.RingTopo,
+        'Mesh': net.topologies.MeshTopo
     }
 
     """
@@ -230,7 +230,7 @@ class Multinet(mininet.net.Mininet):
             # ping the void
             host.sendCmd('ping -c{0} {1}'.format(str(ping_cnt),
                                                  str(self.controllers[0].IP())))
-            
+
         logging.debug('[mininet] Hosts should be visible now')
 
     def get_switches(self):


### PR DESCRIPTION
NSTAT topology definition within the input json file is aligned now with
Multinet and fully functional. A small change in the Multinet code has
been committed so that NSTAT/Multinet are aligned as far as topology
definition is concerned. See NSTAT commit id: regarding
https://github.com/intracom-telecom-sdn/nstat/commit/6f0bd2aac52b14f759074a2fa8090c38709cd341