### PR TITLE
Add "get total flows" endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ as follows:
     - Python 2.7
     - `bottle`, `requests` and `paramiko` Python packages
     - a recent version of Mininet (we support 2.2.1rc)
+    - [Mausezahn](http://www.perihel.at/sec/mz/), tool for network traffic generation.
 - Connectivity:
     - the machines should be able to communicate with each other
     - the machines should have SSH connectivity

--- a/README.md
+++ b/README.md
@@ -326,6 +326,21 @@ If the distributed topologies have been successfully booted, you should
 get a `200 OK` message and the number of switches booted on each worker node.
 
 
+##### Get the number of installed flows on switches of the topology
+
+To query Multinet for the number of all installed flows on topology switches on
+each worker, we can use the following command:
+
+   ```bash
+   [user@machine multinet/]$ bin/handlers/get_flows --json-config config/config.json
+   ```
+
+With this command on each switch we get a dump of its flows and we count them.
+For each worker we add the different counts of switches flows and we get the
+total installed flows for all the switches on the worker node. We return the
+per Multinet worker total installed flows.
+
+
 ##### Do a pingall operation
 
 To perform a "pingall" operation on every worker node in parallel run the following

--- a/bin/handlers/get_flows
+++ b/bin/handlers/get_flows
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-"""Get the number of started switches
-Command line handler to get the number of started switches
-from the distributed topologies
+"""Get the number of flows for each worker of multinet
+Command line handler to get the number of flows from each worker of the multinet
+topology
 """
 
 import util.multinet_requests as m_util

--- a/bin/handlers/get_flows
+++ b/bin/handlers/get_flows
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""Get the number of started switches
+Command line handler to get the number of started switches
+from the distributed topologies
+"""
+
+import util.multinet_requests as m_util
+
+
+def get_flows_main():
+    """Main
+    Send a POST request to the master 'get_flows' endpoint,
+    validate the response code and print the responses
+
+    Usage:
+      bin/handler/get_flows --json-config <path-to-json-conf>
+
+    Example:
+      bin/handler/get_flows --json-config config/runtime_config.json
+
+    Command Line Arguments:
+      json-config (str): Path to the JSON configuration file to be used
+    """
+    conf, _ = m_util.parse_json_conf()
+
+    res = m_util.master_cmd(conf['master_ip'],
+                            conf['master_port'],
+                            'get_flows')
+
+    m_util.handle_post_request(res, exit_on_fail=False)
+
+if __name__ == '__main__':
+    get_flows_main()

--- a/config/config.json
+++ b/config/config.json
@@ -1,22 +1,22 @@
 {
-  "master_ip" : "192.168.100.21",
+  "master_ip" : "10.1.1.90",
   "master_port": 3300,
-  "worker_ip_list": ["192.168.100.21", "192.168.100.22", "192.168.100.23"],
-  "worker_port_list": [3333, 3333, 3333],
+  "worker_ip_list": ["10.1.1.90", "10.1.1.91"],
+  "worker_port_list": [3333, 3333],
         "deploy": {
-    "multinet_base_dir": "/home/konpap/SW/intracom/multinet/multinet_src/",
+    "multinet_base_dir": "/home/vagrant/multinet",
     "ssh_port": 22,
     "username": "vagrant",
     "password": "vagrant"
   },
   "topo": {
-    "controller_ip_address":"192.168.100.22",
+    "controller_ip_address":"10.1.38.45",
     "controller_of_port":6653,
     "switch_type":"ovsk",
     "topo_type":"linear",
-    "topo_size":10,
+    "topo_size":400,
     "group_size":1,
-    "group_delay":10,
+    "group_delay":100,
     "hosts_per_switch":2,
     "traffic_generation_duration_ms":60000,
     "interpacket_delay_ms":5000

--- a/config/config.json
+++ b/config/config.json
@@ -1,22 +1,22 @@
 {
-  "master_ip" : "10.1.1.90",
+  "master_ip" : "192.168.100.21",
   "master_port": 3300,
-  "worker_ip_list": ["10.1.1.90", "10.1.1.91"],
-  "worker_port_list": [3333, 3333],
+  "worker_ip_list": ["192.168.100.21", "192.168.100.22", "192.168.100.23"],
+  "worker_port_list": [3333, 3333, 3333],
         "deploy": {
-    "multinet_base_dir": "/home/vagrant/multinet",
+    "multinet_base_dir": "/home/konpap/SW/intracom/multinet/multinet_src/",
     "ssh_port": 22,
     "username": "vagrant",
     "password": "vagrant"
   },
   "topo": {
-    "controller_ip_address":"10.1.38.45",
+    "controller_ip_address":"192.168.100.22",
     "controller_of_port":6653,
     "switch_type":"ovsk",
     "topo_type":"linear",
-    "topo_size":400,
+    "topo_size":10,
     "group_size":1,
-    "group_delay":100,
+    "group_delay":10,
     "hosts_per_switch":2,
     "traffic_generation_duration_ms":60000,
     "interpacket_delay_ms":5000

--- a/multi/master.py
+++ b/multi/master.py
@@ -100,6 +100,21 @@ def get_switches():
     stat, bod = m_util.aggregate_broadcast_response(reqs)
     return bottle.HTTPResponse(status=stat, body=bod)
 
+@bottle.route('/get_flows', method='POST')
+def get_flows():
+    """
+    Broadcast the POST request to the 'get_flows' endpoint of the workers
+    Aggregate the responses
+
+    Returns:
+        requests.models.Response: An HTTP Response with the aggregated
+        status codes and bodies of the broadcasted requests
+    """
+    reqs = m_util.broadcast_cmd(WORKER_IP_LIST, WORKER_PORT_LIST,
+                                'get_flows')
+    stat, bod = m_util.aggregate_broadcast_response(reqs)
+    return bottle.HTTPResponse(status=stat, body=bod)
+
 
 @bottle.route('/stop', method='POST')
 def stop():

--- a/multi/worker.py
+++ b/multi/worker.py
@@ -104,7 +104,7 @@ def get_flows():
     Returns
         str: A JSON string with dpid_offset/number_of_switches key/value pairs
     """
-    dpid_key = 'dpid-{0}'.format(MININET_TOPO._dpid_offset)
+    dpid_key = 'number-of-flows-on-worker-{0}'.format(MININET_TOPO._dpid_offset)
     total_worker_flows = MININET_TOPO.get_flows()
     return json.dumps({dpid_key: total_worker_flows})
 

--- a/multi/worker.py
+++ b/multi/worker.py
@@ -105,8 +105,8 @@ def get_flows():
         str: A JSON string with dpid_offset/number_of_switches key/value pairs
     """
     dpid_key = 'dpid-{0}'.format(MININET_TOPO._dpid_offset)
-    num_sw = MININET_TOPO.get_flows()
-    return json.dumps({dpid_key: num_sw})
+    total_worker_flows = MININET_TOPO.get_flows()
+    return json.dumps({dpid_key: total_worker_flows})
 
 @bottle.route('/stop', method='POST')
 def stop():

--- a/multi/worker.py
+++ b/multi/worker.py
@@ -95,6 +95,18 @@ def get_switches():
     num_sw = MININET_TOPO.get_switches()
     return json.dumps({dpid_key: num_sw})
 
+@bottle.route('/get_flows', method='POST')
+def get_flows():
+    """
+    Calls the get_flows() method of the current topology object to get the
+    current number of flows installed on the switches.
+
+    Returns
+        str: A JSON string with dpid_offset/number_of_switches key/value pairs
+    """
+    dpid_key = 'dpid-{0}'.format(MININET_TOPO._dpid_offset)
+    num_sw = MININET_TOPO.get_flows()
+    return json.dumps({dpid_key: num_sw})
 
 @bottle.route('/stop', method='POST')
 def stop():

--- a/net/multinet.py
+++ b/net/multinet.py
@@ -297,6 +297,13 @@ class Multinet(mininet.net.Mininet):
 
         return source_mac, dest_mac
 
+    def get_flows(self):
+        """
+        Getting flows from switches
+        """
+        logging.info('[get_flows] Getting flows from switches.')
+
+
     def generate_traffic(self):
         """
         Traffic generation from switches to controller

--- a/net/multinet.py
+++ b/net/multinet.py
@@ -302,7 +302,15 @@ class Multinet(mininet.net.Mininet):
         Getting flows from switches
         """
         logging.info('[get_flows] Getting flows from switches.')
+        flow_number_total = 0
+        for switch in self.switches:
+            logging.info(switch.dpctl('-O OpenFlow13 dump-flows'))
+            flows_list = switch.dpctl('-O OpenFlow13 dump-flows').split('\n')
+            flow_number = len(flows_list) - 2
+            flow_number_total += flow_number
 
+        logging.info('number of flows: {0}'.format(flow_number_total))
+        return flow_number_total
 
     def generate_traffic(self):
         """

--- a/net/multinet.py
+++ b/net/multinet.py
@@ -274,6 +274,22 @@ class Multinet(mininet.net.Mininet):
         """
         self.pingAll(timeout=None)
 
+
+    def get_flows(self):
+        """
+        Getting flows from switches
+        """
+        logging.info('[get_flows] Getting flows from switches.')
+        flow_number_total = 0
+        for switch in self.switches:
+            flows_list = switch.dpctl('-O OpenFlow13 dump-flows').split('\n')
+            flow_number = len(flows_list) - 2
+            flow_number_total += flow_number
+
+        logging.debug('[get_flows] number of flows: {0}'.format(flow_number_total))
+        return flow_number_total
+
+
     def generate_mac_address_pairs(self, current_mac):
         """
         Generated tuple of source/destination mac addressess
@@ -294,23 +310,8 @@ class Multinet(mininet.net.Mininet):
 
         source_mac = ':'.join(''.join(pair) for pair in zip(*[iter(hex(int(generated_mac, 16) + 1))]*2))[6:]
         dest_mac = ':'.join(''.join(pair) for pair in zip(*[iter(hex(int(generated_mac, 16) + 2))]*2))[6:]
-
         return source_mac, dest_mac
 
-    def get_flows(self):
-        """
-        Getting flows from switches
-        """
-        logging.info('[get_flows] Getting flows from switches.')
-        flow_number_total = 0
-        for switch in self.switches:
-            logging.info(switch.dpctl('-O OpenFlow13 dump-flows'))
-            flows_list = switch.dpctl('-O OpenFlow13 dump-flows').split('\n')
-            flow_number = len(flows_list) - 2
-            flow_number_total += flow_number
-
-        logging.info('number of flows: {0}'.format(flow_number_total))
-        return flow_number_total
 
     def generate_traffic(self):
         """
@@ -330,7 +331,6 @@ class Multinet(mininet.net.Mininet):
         transmission_start = time.time()
         last_mac = hex(int(hex(self._dpid_offset) + '00000000', 16) + 0xffffffff)
         current_mac = hex(int(last_mac, 16) - 0x0000ffffffff + 0x000000000001)
-
 
         while (time.time() - transmission_start) <= traffic_transmission_interval:
             src_mac, dst_mac = self.generate_mac_address_pairs(current_mac)
@@ -360,9 +360,4 @@ class Multinet(mininet.net.Mininet):
         # transmission
         for host in self.hosts:
             host.waitOutput()
-
-
-
-
-
 


### PR DESCRIPTION
For testing new functionality
1. launch ie three workers with IPs 192.168.100.21,192.168.100.22,192.168.100.23
2. bin/deploy --json-config config/config.json
3. bin/handlers/init_topos --json-config config/config.json
4. bin/handlers/start_topos --json-config config/config.json

add some flows to the switches of each worker ie if 10 switches per worker and number of workers =3

**Worker 1**
```bash
sudo ovs-ofctl -O OpenFlow13 add-flow 1 'priority=2,icmp,actions=CONTROLLER:65535'
sudo ovs-ofctl -O OpenFlow13 add-flow 1 'priority=2,ip,actions=CONTROLLER:65535'
sudo ovs-ofctl -O OpenFlow13 add-flow 1 'priority=2,arp,actions=CONTROLLER:65535'
```

**Worker 3**
```bash
sudo ovs-ofctl -O OpenFlow13 add-flow 21 'priority=2,icmp,actions=CONTROLLER:65535'
sudo ovs-ofctl -O OpenFlow13 add-flow 22 'priority=2,ip,actions=CONTROLLER:65535'
sudo ovs-ofctl -O OpenFlow13 add-flow 23 'priority=2,arp,actions=CONTROLLER:65535'
```

5. bin/handlers/get_flows --json-config config/config.json

Results should be

```bash
["{\"dpid-0\": 3}", "{\"dpid-1\": 0}", "{\"dpid-2\": 3}"]
```
